### PR TITLE
Fix the Buffer not found error in client

### DIFF
--- a/client/lib/init.js
+++ b/client/lib/init.js
@@ -1,0 +1,1 @@
+global.Buffer = global.Buffer || require("buffer").Buffer; // eslint-disable-line

--- a/imports/ui/App.vue
+++ b/imports/ui/App.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script>
-  global.Buffer = global.Buffer || require("buffer").Buffer;
   import steem from 'steem';
 
   // Main function to connect to the Steem API

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,6 +315,14 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
+    "bufferutil": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npm.taobao.org/bufferutil/download/bufferutil-4.0.1.tgz",
+      "integrity": "sha1-Ohd+jlgZoSQ/4WtjoZmVGnrY1Kc=",
+      "requires": {
+        "node-gyp-build": "3.7.0"
+      }
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -833,8 +841,8 @@
     },
     "meteor-node-stubs": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-0.3.3.tgz",
-      "integrity": "sha512-TI1aQRK0vqs94OCkUMkmf5lXNWfIsjSaEDP1inUuwRGt9w8/S2V+HdRikz9r1k/gew+7NcJieaqHsHX7pSTEgA==",
+      "resolved": "https://registry.npm.taobao.org/meteor-node-stubs/download/meteor-node-stubs-0.3.3.tgz",
+      "integrity": "sha1-QDfsRkVzZCsO/uOWGmSaSBj3lts=",
       "requires": {
         "assert": "1.4.1",
         "browserify-zlib": "0.1.4",
@@ -1886,8 +1894,8 @@
     },
     "steem": {
       "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/steem/-/steem-0.7.7.tgz",
-      "integrity": "sha512-he9ljjB9vih/cpq+Ip0CfcfLWHKngy2ueSzS3n8vJf0cH3hLLCFkzo0M+OrJnM7grPgYRUqKPjDS5//5YeInAw==",
+      "resolved": "https://registry.npm.taobao.org/steem/download/steem-0.7.7.tgz",
+      "integrity": "sha1-sjKR0oqxOgd7UxIyp+KIM9Z2Q9c=",
       "requires": {
         "@steemit/rpc-auth": "1.1.1",
         "bigi": "1.4.2",
@@ -2092,9 +2100,9 @@
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "vue": {
-      "version": "2.5.22",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.22.tgz",
-      "integrity": "sha512-pxY3ZHlXNJMFQbkjEgGVMaMMkSV1ONpz+4qB55kZuJzyJOhn6MSy/YZdzhdnumegNzVTL/Dn3Pp4UrVBYt1j/g=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.10.tgz",
+      "integrity": "sha1-pysaQqTYKnIepDjRtr9V5mGVxjc="
     },
     "vue-meteor-tracker": {
       "version": "2.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.55",
-    "browserify": "^16.5.0",
     "buffer": "^5.4.2",
+    "bufferutil": "^4.0.1",
     "diff": "^4.0.1",
     "meteor-node-stubs": "^0.3.3",
     "meteor-stubs": "0.0.6",
     "sockjs": "^0.3.19",
     "steem": "^0.7.7",
     "utf-8-validate": "^5.0.2",
-    "vue": "^2.5.22",
+    "vue": "^2.6.10",
     "vue-meteor-tracker": "^2.0.0-beta.5",
     "vue-router": "^2.0.0"
   },


### PR DESCRIPTION
### Issue

The client will throw "Buffer not found/defined" error in meteor production mode. 
Reproduce locally with `meteor --production`.

### Fix
1. add `global.Buffer = global.Buffer || require("buffer").Buffer; ` in client/lib/init.js
